### PR TITLE
10 sync missing parent UUID in asset table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /venv/
 /.idea/
+/.venv/

--- a/EMInfraImporter.py
+++ b/EMInfraImporter.py
@@ -36,6 +36,13 @@ class EMInfraImporter:
         filter_string = '{ "uuid": ' + f'["{asset_list_string}"]' + ' }'
         yield from self.get_objects_from_oslo_search_endpoint(url_part='assets', filter_string=filter_string)
 
+    def import_assets_from_non_oslo_webservice_by_uuids(self, asset_uuids: [str]) -> [dict]:
+        zoek_params = ZoekParameterPayload()
+        zoek_params.expansions = {'fields': ['parent']}
+        zoek_params.add_term(property='id', value=list(asset_uuids), operator='IN')
+        yield from self.get_objects_from_non_oslo_endpoint(url_part='assets/search', zoek_payload=zoek_params,
+                                                           request_type='POST')
+
     def import_all_agents_from_webservice(self) -> [dict]:
         expansions_string = '{"fields": ["contactInfo"]}'
         return self.get_objects_from_oslo_search_endpoint(url_part='agents', expansions_string=expansions_string)

--- a/EventProcessors/AssetProcessors/NaamGewijzigdProcessor.py
+++ b/EventProcessors/AssetProcessors/NaamGewijzigdProcessor.py
@@ -26,7 +26,7 @@ class NaamGewijzigdProcessor(SpecificEventProcessor):
         counter = 0
         for asset_dict in assets_dicts:
             counter += 1
-            uuid = asset_dict['uuid'][0:36]
+            uuid = asset_dict['uuid'][:36]
 
             naam = None
             if 'naam' in asset_dict:

--- a/EventProcessors/AssetProcessors/NaamGewijzigdProcessor.py
+++ b/EventProcessors/AssetProcessors/NaamGewijzigdProcessor.py
@@ -2,6 +2,7 @@ import logging
 import time
 
 from EventProcessors.AssetProcessors.SpecificEventProcessor import SpecificEventProcessor
+from Helpers import construct_naampad
 
 
 class NaamGewijzigdProcessor(SpecificEventProcessor):
@@ -12,10 +13,9 @@ class NaamGewijzigdProcessor(SpecificEventProcessor):
         logging.info(f'started changing naam/naampad/parent')
         start = time.time()
 
-        asset_dicts = self.eminfra_importer.import_assets_from_webservice_by_uuids(asset_uuids=uuids)
+        asset_dicts = self.eminfra_importer.import_assets_from_non_oslo_webservice_by_uuids(asset_uuids=uuids)
         values, amount = self.create_values_string_from_dicts(assets_dicts=asset_dicts)
         self.perform_update_with_values(connection=connection, values=values)
-        # TODO change parent uuid as well
 
         end = time.time()
         logging.info(f'updated naam/naampad/parent of {amount} asset(s) in {str(round(end - start, 2))} seconds.')
@@ -26,17 +26,19 @@ class NaamGewijzigdProcessor(SpecificEventProcessor):
         counter = 0
         for asset_dict in assets_dicts:
             counter += 1
-            uuid = asset_dict['@id'].replace('https://data.awvvlaanderen.be/id/asset/', '')[0:36]
+            uuid = asset_dict['uuid'][0:36]
 
             naam = None
-            if 'AIMNaamObject.naam' in asset_dict:
-                naam = asset_dict['AIMNaamObject.naam']
-            elif 'AbstracteAanvullendeGeometrie.naam' in asset_dict:
-                naam = asset_dict['AbstracteAanvullendeGeometrie.naam']
+            if 'naam' in asset_dict:
+                naam = asset_dict['naam']
 
             naampad = None
-            if 'NaampadObject.naampad' in asset_dict:
-                naampad = asset_dict['NaampadObject.naampad']
+            if 'parent' in asset_dict:
+                naampad = construct_naampad(asset_dict)
+
+            parent = None
+            if 'parent' in asset_dict:
+                parent = asset_dict['parent']['uuid'][:36]
 
             values += f"('{uuid}',"
 
@@ -51,18 +53,25 @@ class NaamGewijzigdProcessor(SpecificEventProcessor):
             else:
                 naampad = naampad.replace("'", "''")
                 values += f",'{naampad}'"
+
+            if parent is None:
+                values += ',NULL'
+            else:
+                parent = parent.replace("'", "''")
+                values += f",'{parent}'"
+
             values = values + '),'
         return values, counter
 
     @staticmethod
     def perform_update_with_values(connection, values):
         update_query = f"""
-        WITH s (uuid, naam, naampad)  
+        WITH s (uuid, naam, naampad, parent)  
             AS (VALUES {values[:-1]}),
         to_update AS (
-            SELECT uuid::uuid AS uuid, naam, naampad FROM s)
+            SELECT uuid::uuid AS uuid, naam, naampad, parent::uuid as parent FROM s)
         UPDATE assets 
-        SET naam = to_update.naam, naampad = to_update.naampad
+        SET naam = to_update.naam, naampad = to_update.naampad, parent = to_update.parent
         FROM to_update 
         WHERE to_update.uuid = assets.uuid;"""
 

--- a/Helpers.py
+++ b/Helpers.py
@@ -28,3 +28,19 @@ def chunked(seq, chunksize):
     """Yields items from an iterator in list chunks."""
     for chunk in ichunked(seq, chunksize):
         yield list(chunk)
+
+def construct_naampad(input_dict: dict) -> str:
+    """
+    Construct naampad by walking recursively in a nested "parent" dictionary, searching for the "naam" key.
+    Concatenates all "naam" values, starting from the top of the nested tree.
+    :param input_dict:
+    :return: str
+    """
+    naam_list = []
+    while "naam" in input_dict:
+        naam_list.insert(0, input_dict["naam"]) # insert at first list index position
+        if "parent" in input_dict:
+            input_dict = input_dict["parent"]
+        else:
+            break
+    return "/".join(naam_list)  # concatenate naampad, using "/" as a separator character


### PR DESCRIPTION
- Changed the API-call using the OSLO-compliant otl/assets search-call to the non-OSLO-compliant assets search call.
- Changed the processing of the response
- Changed the update query
- Include the attribute "parent" (parent-uuid) in the update-query.

## Summary by Sourcery

Update the asset table to include the parent UUID. This change involves switching to a non-OSLO compliant API call to retrieve the parent UUID, constructing the naampad, and updating the asset table with the new parent UUID.